### PR TITLE
ci: fix empty imageToDeploy in test/prod Container App deploys

### DIFF
--- a/.github/workflows/container_app_deployment.yml
+++ b/.github/workflows/container_app_deployment.yml
@@ -18,8 +18,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    # Note: only `full_version` (the tag) is exported as a job output. We
+    # cannot include the registry URL in an output because GitHub redacts any
+    # step/job output value that contains a registered secret, which made
+    # `imageToDeploy` arrive empty in dependent jobs. Deploy jobs reassemble
+    # the full image reference from the secret + tag at consumption time.
     outputs:
-      image: ${{ steps.meta.outputs.image }}
       full_version: ${{ steps.meta.outputs.full_version }}
     steps:
       - name: Checkout
@@ -30,10 +34,8 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           FULL_VERSION="${VERSION}-${{ github.run_number }}"
-          IMAGE="${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${FULL_VERSION}"
           echo "full_version=${FULL_VERSION}" >> $GITHUB_OUTPUT
-          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
-          echo "Image: ${IMAGE}"
+          echo "Tag: ${FULL_VERSION}"
 
       - name: Azure login
         uses: azure/login@v2
@@ -56,7 +58,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ steps.meta.outputs.image }}
+            ${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${{ steps.meta.outputs.full_version }}
             ${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:latest
 
   deploy-test:
@@ -82,7 +84,7 @@ jobs:
         with:
           containerAppName: ${{ env.TEST_CONTAINER_APP }}
           resourceGroup: ${{ env.RESOURCE_GROUP }}
-          imageToDeploy: ${{ needs.build.outputs.image }}
+          imageToDeploy: ${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${{ needs.build.outputs.full_version }}
 
   deploy-prod:
     name: Deploy to production
@@ -109,4 +111,4 @@ jobs:
         with:
           containerAppName: ${{ env.PROD_CONTAINER_APP }}
           resourceGroup: ${{ env.RESOURCE_GROUP }}
-          imageToDeploy: ${{ needs.build.outputs.image }}
+          imageToDeploy: ${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${{ needs.build.outputs.full_version }}


### PR DESCRIPTION
## Problem

The deploy-test job in the new release pipeline failed with:

> `One of the following arguments must be provided: 'appSourcePath', 'imageToDeploy', or 'yamlConfigPath'.`

Workflow run: https://github.com/TabTabGo/tabtabgo-pdf-generator/actions/runs/25172374364

## Root cause

The `build` job exported `image` as a job output, computed as:

```
IMAGE="${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${FULL_VERSION}"
echo "image=${IMAGE}" >> $GITHUB_OUTPUT
```

GitHub Actions **redacts any step/job output value that contains a registered secret** to prevent secret leakage between jobs. Since `IMAGE` embedded the registry URL secret, the entire `image` output was blanked out, leaving `needs.build.outputs.image` empty in `deploy-test` and `deploy-prod`. The Azure Container Apps deploy action then failed because `imageToDeploy` was empty.

The `Set output 'image'` line was also missing from the build job's "Complete job" log (only `full_version` was set), confirming the redaction.

## Fix

- Build job now exports only `full_version` (the tag, no secret).
- `Build & push image`, `deploy-test`, and `deploy-prod` reassemble the full image reference inline using `${{ secrets.SERVICES_REGISTRY_URL }}/services-generator:${{ ... full_version }}`.
- Comment added explaining the constraint so we don't reintroduce the bug.

Federated identity credentials for the new `environment:test` and `environment:production` subjects were already added separately to UAMI `tabstabsOidc` so the Azure logins now succeed; this PR fixes the next failure surfaced by the rerun.

## Test plan

- [ ] Merge to master
- [ ] Confirm `Build & push image` job logs `Set output 'full_version'`
- [ ] Confirm `deploy-test` job's `imageToDeploy` arg is non-empty
- [ ] Confirm test Container App `ca-services-generator-test` rolls to the new image
- [ ] Approve the production gate and confirm `deploy-prod` rolls `ca-services-generator`